### PR TITLE
Specify the license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/expo/expo-2d-context.git"
   },
+  "license": "MIT",
   "scripts": {
     "build": "esbuild src/exports.js --bundle --outfile=dist/bundle.js --loader:.png=dataurl",
     "lint": "eslint src",


### PR DESCRIPTION
The package doesn't have any license specified. Some companies require specific licenses in order to use the package.