### PR TITLE
Make maxWidth optional for TypeScript

### DIFF
--- a/src/Expo2DContext.d.ts
+++ b/src/Expo2DContext.d.ts
@@ -67,7 +67,7 @@ export default class Expo2DContext {
   drawImage(): void;
   measureText(text: string): TextMetrics;
   initializeText(): Promise<void>;
-  fillText(text: string, x: number, y: number, maxWidth: number): void;
+  fillText(text: string, x: number, y: number, maxWidth?: number): void;
   strokeText(text: string, x: number, y: number, maxWidth: number): void;
   clearRect(x: number, y: number, w: number, h: number): void;
   fillRect(x: number, y: number, w: number, h: number): void;

--- a/src/Expo2DContext.js
+++ b/src/Expo2DContext.js
@@ -958,6 +958,8 @@ export default class Expo2DContext {
   }
 
   fillText(text, x, y, maxWidth) {
+    // If three arguments are required, then maxWidth shouldn't be needed, and
+    // is only required when needed.
     if (arguments.length !== 3 && arguments.length !== 4) throw new TypeError();
     this._drawText(text, x, y, maxWidth, -1);
   }


### PR DESCRIPTION
TypeScript throws errors whenever I do not supply `maxWidth`. However, `maxWidth` is optional since three arguments are required and remains optional.